### PR TITLE
useContext + useReducer サンプル実装

### DIFF
--- a/src/sample-useContext/components/DeviceList.css
+++ b/src/sample-useContext/components/DeviceList.css
@@ -1,0 +1,27 @@
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+table th {
+  border-bottom: 1px solid black;
+  padding: 0 0 6px 0;  
+}
+
+table td {
+  padding: 8px 0 0 0;
+}
+
+.device-list-cell-name {
+  text-align: left;
+  width: 140px;
+}
+
+.device-list-cell-model {
+  text-align: left;
+  width: 140px;
+}
+
+.device-list-cell-button {
+  text-align: left;
+}

--- a/src/sample-useContext/components/DeviceList.tsx
+++ b/src/sample-useContext/components/DeviceList.tsx
@@ -1,0 +1,59 @@
+import DeviceListItem from "./DeviceListItem";
+import "./DeviceList.css";
+import { useContext } from "react";
+import { DeviceContext } from "../store/context";
+
+export type Device = {
+  id: string;
+  name: string;
+  model: string;
+};
+
+type DeviceListProps = {
+  onDelete: (id: string) => void;
+  onUpdate: (id: string, param: { name?: string; model?: string }) => void;
+};
+
+function DeviceList({ onDelete, onUpdate }: DeviceListProps) {
+  const state = useContext(DeviceContext);
+
+  const DeviceListHeader = () => {
+    return (
+      <thead>
+        <tr>
+          <th className="device-list-cell-name">Name</th>
+          <th className="device-list-cell-model">Model</th>
+          <th className="device-list-cell-button"></th>
+        </tr>
+      </thead>
+    );
+  };
+
+  const DeviceListBody = () => {
+    return (
+      <tbody>
+        {state.deviceList.map((device) => {
+          return (
+            <DeviceListItem
+              key={device.id}
+              id={device.id}
+              name={device.name}
+              model={device.model}
+              onDelete={onDelete}
+              onUpdate={onUpdate}
+            />
+          );
+        })}
+      </tbody>
+    );
+  };
+
+  return (
+    <table>
+      <DeviceListHeader />
+      <DeviceListBody />
+    </table>
+  );
+}
+
+export default DeviceList;

--- a/src/sample-useContext/components/DeviceListItem.css
+++ b/src/sample-useContext/components/DeviceListItem.css
@@ -1,0 +1,9 @@
+.device-list-item-input {
+  width: 120px;
+}
+
+.device-list-item-button-area {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/src/sample-useContext/components/DeviceListItem.tsx
+++ b/src/sample-useContext/components/DeviceListItem.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import "./DeviceListItem.css";
+
+type DeviceListItemProps = {
+  id: string;
+  name: string;
+  model: string;
+  onDelete: (id: string) => void;
+  onUpdate: (id: string, param: { name?: string; model?: string }) => void;
+};
+
+type DevictListItemEditorProps = {
+  initialName: string;
+  initialModel: string;
+  onClickUpdateButton: (name: string, model: string) => void;
+};
+
+function DeviceListItem({
+  id,
+  name,
+  model,
+  onDelete,
+  onUpdate,
+}: DeviceListItemProps) {
+  const [isEditMode, setEditMode] = useState(false);
+
+  const onClickEditButton = () => {
+    setEditMode(true);
+  };
+
+  const onClickDeleteButton = () => {
+    onDelete(id);
+  };
+
+  const onClickUpdateButton = (newName: string, newModel: string) => {
+    onUpdate(id, { name: newName, model: newModel });
+    setEditMode(false);
+  };
+
+  const DeviceListItemView = () => {
+    return (
+      <tr key={id}>
+        <td>{name}</td>
+        <td>{model}</td>
+        <td>
+          <div className="device-list-item-button-area">
+            <button onClick={onClickEditButton}>Edit</button>
+            <button onClick={onClickDeleteButton}>Delete</button>
+          </div>
+        </td>
+      </tr>
+    );
+  };
+
+  const DeviceListItemEditor = ({
+    initialName,
+    initialModel,
+  }: DevictListItemEditorProps) => {
+    const [newName, setNewName] = useState(initialName);
+    const [newModel, setNewModel] = useState(initialModel);
+
+    return (
+      <tr key={id}>
+        <td>
+          <input
+            className="device-list-item-input"
+            value={newName}
+            onChange={(e) => {
+              setNewName(e.target.value);
+            }}
+          />
+        </td>
+        <td>
+          <input
+            className="device-list-item-input"
+            value={newModel}
+            onChange={(e) => {
+              setNewModel(e.target.value);
+            }}
+          />
+        </td>
+        <td>
+          <div className="device-list-item-button-area">
+            <button
+              onClick={() => {
+                setEditMode(false);
+              }}
+            >
+              cancel
+            </button>
+            <button
+              onClick={() => {
+                onClickUpdateButton(newName, newModel);
+              }}
+            >
+              update
+            </button>
+          </div>
+        </td>
+      </tr>
+    );
+  };
+
+  if (isEditMode) {
+    return (
+      <DeviceListItemEditor
+        initialName={name}
+        initialModel={model}
+        onClickUpdateButton={onClickUpdateButton}
+      />
+    );
+  } else {
+    return <DeviceListItemView />;
+  }
+}
+
+export default DeviceListItem;

--- a/src/sample-useContext/components/DeviceRegistrationForm.css
+++ b/src/sample-useContext/components/DeviceRegistrationForm.css
@@ -1,0 +1,23 @@
+.device-registration-form-header {
+  font-weight: bold;
+  border-bottom: 1px solid black;
+  padding: 0 0 6px 0;
+  margin: 0 0 6px 0;
+}
+
+.device-registration-form-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 5px 0;
+}
+
+.device-registration-form-row-input {
+  width: 240px;
+}
+
+.device-registration-button-area {
+  display: flex;
+  justify-content: flex-end;
+  margin: 5px 0;
+}

--- a/src/sample-useContext/components/DeviceRegistrationForm.tsx
+++ b/src/sample-useContext/components/DeviceRegistrationForm.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import "./DeviceRegistrationForm.css";
+
+function DeviceRegistrationForm({
+  onRegister,
+}: {
+  onRegister: (name: string, model: string) => void;
+}) {
+  const [name, setName] = useState("");
+  const [model, setModel] = useState("");
+
+  const onClickRegistrationButton = () => {
+    setName("");
+    setModel("");
+    onRegister(name, model);
+  };
+
+  return (
+    <div>
+      <div className="device-registration-form-header">Registration</div>
+      <div className="device-registration-form-row">
+        <div>Name</div>
+        <input
+          className="device-registration-form-row-input"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+          }}
+        />
+      </div>
+      <div className="device-registration-form-row">
+        <div>Model</div>
+        <input
+          className="device-registration-form-row-input"
+          value={model}
+          onChange={(e) => {
+            setModel(e.target.value);
+          }}
+        />
+      </div>
+      <div className="device-registration-button-area">
+        <button onClick={onClickRegistrationButton}>Register</button>
+      </div>
+    </div>
+  );
+}
+
+export default DeviceRegistrationForm;

--- a/src/sample-useContext/components/SearchPanel.css
+++ b/src/sample-useContext/components/SearchPanel.css
@@ -1,0 +1,29 @@
+.search-panel-main {
+  border: 1px solid black;
+  padding: 5px;
+}
+
+.search-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.search-panel-header-label {
+  font-weight: bold;
+}
+
+.search-panel-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 5px 0 0 0;
+}
+
+.search-panel-row-label {
+  width: 80px;
+}
+
+.search-panel-row-input {
+  width: 240px;
+}

--- a/src/sample-useContext/components/SearchPanel.tsx
+++ b/src/sample-useContext/components/SearchPanel.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+
+export type SearchParam = {
+  name?: string;
+  model?: string;
+};
+
+export default function SearchPanel({
+  onSearch,
+}: {
+  onSearch: (searchParam: SearchParam) => void;
+}) {
+  const [name, setName] = useState("");
+  const [model, setModel] = useState("");
+
+  const onClickSearchButton = () => {
+    const param: SearchParam = {};
+    if (name !== "") {
+      param["name"] = name;
+    }
+    if (model !== "") {
+      param["model"] = model;
+    }
+    onSearch(param);
+  };
+
+  function onClickClearButton() {
+    setName("");
+    setModel("");
+    onSearch({});
+  }
+
+  return (
+    <div className="search-panel-main">
+      <div className="search-panel-header">
+        <div className="search-panel-header-label">Search</div>
+        <div>
+          <button onClick={onClickSearchButton}>Search</button>
+          <button onClick={onClickClearButton}>Clear</button>
+        </div>
+      </div>
+      <div className="search-panel-row">
+        <div className="search-panel-row-label">Name</div>
+        <input
+          className="search-panel-row-input"
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+          }}
+        />
+      </div>
+      <div className="search-panel-row">
+        <div className="search-panel-row-label">Model</div>
+        <input
+          className="search-panel-row-input"
+          value={model}
+          onChange={(e) => {
+            setModel(e.target.value);
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/sample-useContext/index.tsx
+++ b/src/sample-useContext/index.tsx
@@ -1,14 +1,74 @@
-import { Link } from "react-router-dom"
+import { useContext, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { DeviceContextProvider, DeviceDispatchContext } from "./store/context";
+import {
+  fetchDevices,
+  registerDevice,
+  updateDevice,
+  deleteDevice,
+} from "../ApiRequest";
+import { actions, SearchParam } from "./store/reducer";
+import SearchPanel from "./components/SearchPanel";
+import DeviceList from "./components/DeviceList";
+import DeviceRegistrationForm from "./components/DeviceRegistrationForm";
 
-function SampleUseContext () {
+function SampleUseContext() {
   return (
-    <div>
-      <h1>Sample UseContext</h1>
-      <div>
-        <Link to={`/`}>back</Link>        
-      </div>
-    </div>    
-  )
+    <DeviceContextProvider>
+      <Presentational />
+    </DeviceContextProvider>
+  );
 }
 
-export default SampleUseContext
+function Presentational() {
+  const dispatch = useContext(DeviceDispatchContext);
+
+  useEffect(() => {
+    console.log("useEffect");
+    onFetch({});
+  });
+
+  const onFetch = async (searchParam: SearchParam) => {
+    dispatch(actions.startFetch());
+    const res = await fetchDevices(searchParam);
+    dispatch(actions.successFetch(res.data));
+  };
+
+  const onRegister = async (name: string, model: string) => {
+    await registerDevice(name, model);
+    onFetch({});
+  };
+
+  const onUpdate = async (
+    id: string,
+    param: { name?: string; model?: string }
+  ) => {
+    await updateDevice(id, param);
+    onFetch({});
+  };
+
+  const onDelete = async (id: string) => {
+    await deleteDevice(id);
+    onFetch({});
+  };
+
+  return (
+    <div className="sample-use-state-main">
+      <h1>Sample useContext + useReducer</h1>
+      <div className="search-panel">
+        <SearchPanel onSearch={onFetch} />
+      </div>
+      <div className="device-list">
+        <DeviceList onDelete={onDelete} onUpdate={onUpdate} />
+      </div>
+      <div className="device-registration-form">
+        <DeviceRegistrationForm onRegister={onRegister} />
+      </div>
+      <div>
+        <Link to={`/`}>Back</Link>
+      </div>
+    </div>
+  );
+}
+
+export default SampleUseContext;

--- a/src/sample-useContext/store/context.tsx
+++ b/src/sample-useContext/store/context.tsx
@@ -1,0 +1,16 @@
+import { createContext, ReactNode, useReducer } from "react";
+import { State, Dispatch, initState, reducer } from "./reducer";
+
+export const DeviceContext = createContext<State>(initState);
+export const DeviceDispatchContext = createContext<Dispatch>(() => {});
+
+export function DeviceContextProvider({ children }: { children: ReactNode }) {
+  const [deviceList, dispatch] = useReducer(reducer, initState);
+  return (
+    <DeviceDispatchContext.Provider value={dispatch}>
+      <DeviceContext.Provider value={deviceList}>
+        {children}
+      </DeviceContext.Provider>
+    </DeviceDispatchContext.Provider>
+  );
+}

--- a/src/sample-useContext/store/reducer.ts
+++ b/src/sample-useContext/store/reducer.ts
@@ -1,0 +1,69 @@
+export type Device = {
+  id: string;
+  name: string;
+  model: string;
+};
+
+export type SearchParam = {
+  name?: string;
+  model?: string;
+};
+
+export type State = {
+  isLoading: boolean;
+  deviceList: Device[];
+};
+
+export type ActionType =
+  | ReturnType<typeof startFetch>
+  | ReturnType<typeof successFetch>;
+
+export const initState = {
+  isLoading: false,
+  deviceList: [] as Device[],
+};
+
+export function reducer(state: State, action: ActionType): State {
+  console.log("action:", action.type);
+  switch (action.type) {
+    case "START_FETCH": {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    }
+    case "SUCCESS_FETCH": {
+      return {
+        ...state,
+        isLoading: false,
+        deviceList: action.payload,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export const actions = {
+  startFetch,
+  successFetch,
+};
+
+function startFetch() {
+  console.log("dispatch:", "START_FETCH");
+  return {
+    type: "START_FETCH" as const,
+  };
+}
+
+function successFetch(payload: Device[]) {
+  console.log("dispatch:", "SUCCESS_FETCH");
+  return {
+    type: "SUCCESS_FETCH" as const,
+    payload,
+  };
+}
+
+export type Reducer = React.Reducer<State, ActionType>;
+export type Dispatch = React.Dispatch<ActionType>;


### PR DESCRIPTION
## サマリー
useContext + useReducer での状態管理サンプル実装

## ほか
useContext を使うことで、 state をグローバル管理することができる。
context で保持している state に変更があると、その context から値を引っ張ってきているコンポーネントはすべて再レンダリングされてしまう。（アクションのためのボタンさえも）
そのため、 dispatch と state で context を分け、不要なレンダリングを減らすのが定石の模様。